### PR TITLE
Add needed kitchen-rackspace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 
 group :kitchen_common do
   gem 'test-kitchen'
+  gem 'kitchen-rackspace'
 end
 
 group :kitchen_vagrant do


### PR DESCRIPTION
Tests appear to be failing from missing gems. This will hopefully add needed environment items.
