### PR TITLE
Removed space from ini file

### DIFF
--- a/templates/default/nginx/uwsgi.ini.erb
+++ b/templates/default/nginx/uwsgi.ini.erb
@@ -21,8 +21,8 @@ harakiri-verbose = true
 ; https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-and-uwsgi#mandatory-options
 single-interpreter = true
 enable-threads = true
-env = NEW_RELIC_CONFIG_FILE= <%= node['newrelic']['python_agent']['config_file'] %>
-env = NEW_RELIC_LICENSE_KEY= <%= node['newrelic']['license'] %>
+env = NEW_RELIC_CONFIG_FILE=<%= node['newrelic']['python_agent']['config_file'] %>
+env = NEW_RELIC_LICENSE_KEY=<%= node['newrelic']['license'] %>
 <% end %>
 
 <% if @stats_port %>


### PR DESCRIPTION
The ENV variable was not properly set due to the space.

It was setting : 
`env = MYENV= a`
rather than
`env = MYENV=a`
