### PR TITLE
Fixes - Varnish attribute set to array instead of hash

### DIFF
--- a/attributes/varnish.rb
+++ b/attributes/varnish.rb
@@ -20,4 +20,4 @@
 stackname = 'pythonstack'
 
 default[stackname]['varnish']['multi'] = true
-default[stackname]['varnish']['backend_nodes'] = []
+default[stackname]['varnish']['backend_nodes'] = {}


### PR DESCRIPTION
Small change to set the default attribute for:

default[stackname]['varnish']['backend_nodes'] = []

in attributes/varnish.rb to a hash {} instead of array []. 
